### PR TITLE
Fix remove directory windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  tests:
+  linux_tests:
 
     runs-on: ubuntu-latest
     strategy:
@@ -28,6 +28,40 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip
           tools: composer:v2
           coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Execute tests
+        run: vendor/bin/phpunit --verbose
+
+  windows_tests:
+
+    runs-on: windows-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [7.3, 7.4]
+
+    name: PHP ${{ matrix.php }} - Windows
+
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip
+          tools: composer:v2
+          coverage: none
+          ini-values: memory_limit=512M
 
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -87,7 +87,6 @@ class NewCommand extends Command
 
         $commands = [
             $composer." create-project laravel/laravel $directory $version --remove-vcs --prefer-dist",
-            "chmod 644 $directory/artisan",
         ];
 
         if ($directory != '.') {
@@ -95,6 +94,7 @@ class NewCommand extends Command
                 array_unshift($commands, "rd /s /q \"$directory\"");
             } else {
                 array_unshift($commands, "rm -rf $directory");
+				$commands[] = "chmod 644 $directory/artisan";
             }
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -89,13 +89,16 @@ class NewCommand extends Command
             $composer." create-project laravel/laravel $directory $version --remove-vcs --prefer-dist",
         ];
 
-        if ($directory != '.') {
+        if ($directory != '.' && $input->getOption('force')) {
             if (PHP_OS_FAMILY == 'Windows') {
                 array_unshift($commands, "rd /s /q \"$directory\"");
             } else {
                 array_unshift($commands, "rm -rf $directory");
-				$commands[] = "chmod 644 $directory/artisan";
             }
+        }
+
+        if (PHP_OS_FAMILY != 'Windows') {
+            $commands[] = "chmod 644 $directory/artisan";
         }
 
         if ($this->runCommands($commands, $input, $output)->isSuccessful()) {

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -14,7 +14,13 @@ class NewCommandTest extends TestCase
         $scaffoldDirectoryName = 'tests-output/my-app';
         $scaffoldDirectory = __DIR__.'/../'.$scaffoldDirectoryName;
 
-        exec("rm -rf $scaffoldDirectory");
+        if (file_exists($scaffoldDirectory)) {
+            if (PHP_OS_FAMILY == 'Windows') {
+                exec("rd /s /q \"$scaffoldDirectory\"");
+            } else {
+                exec("rm -rf $scaffoldDirectory");
+            }
+        }
 
         $app = new Application('Laravel Installer');
         $app->add(new NewCommand);


### PR DESCRIPTION
This is an extension of laravel/installer/pull/131 (which fixes laravel/installer/issues/128).

This PR also prevents running chmod on Windows (which would equally fail) and only executes the removal of a directory if the `--force`  option has been passed. It also adds tests for for Windows.

Merging this way so that we can close laravel/installer/pull/133 rather than the original laravel/installer/pull/131.